### PR TITLE
Fix: project name mismatch between archive and context (#1)

### DIFF
--- a/bin/episodic-archive
+++ b/bin/episodic-archive
@@ -32,6 +32,7 @@ archive_session() {
     local jsonl_path="$1"
     local skip_summary="${2:-false}"
     local dry_run="${3:-false}"
+    local project_override="${4:-}"
 
     local session_file
     session_file=$(basename "$jsonl_path" .jsonl)
@@ -69,9 +70,13 @@ archive_session() {
         session_id="$session_file"
     fi
 
-    # Derive project name
+    # Derive project name (prefer explicit override, e.g. from CWD)
     local project project_path
-    project=$(episodic_project_from_path "$project_dir")
+    if [[ -n "$project_override" ]]; then
+        project="$project_override"
+    else
+        project=$(episodic_project_from_path "$project_dir")
+    fi
     project_path=$(episodic_project_path_from_dir "$project_dir")
 
     # Calculate duration
@@ -257,7 +262,9 @@ case "$MODE" in
             exit 0
         fi
 
-        archive_session "$LATEST" "$SKIP_SUMMARY" "$DRY_RUN"
+        # Use basename of CWD as project name (reliable, avoids lossy encoding)
+        CWD_PROJECT=$(basename "$CWD")
+        archive_session "$LATEST" "$SKIP_SUMMARY" "$DRY_RUN" "$CWD_PROJECT"
         ;;
 
     all)

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -58,18 +58,57 @@ episodic_log() {
     fi
 }
 
-# Derive project name from a project path like -Users-jane-projects-myapp
+# Derive project name from a Claude projects directory name like
+# -home-user-projects-my-cool-app
+#
+# The encoding (/ -> -) is lossy: we can't distinguish path separators from
+# hyphens in directory names. We resolve this by checking the actual filesystem:
+# try the full reconstructed path first, then progressively strip leading
+# components until we find a real directory and use its basename.
 episodic_project_from_path() {
     local dir_name="$1"
-    # Strip leading dash, split on dashes, take the last segment(s)
-    # e.g. -Users-jane-projects-myapp -> myapp
-    echo "$dir_name" | sed 's/^-//' | rev | cut -d'-' -f1 | rev
+
+    # Reconstruct candidate path: strip leading dash, replace - with /
+    local candidate
+    candidate=$(echo "$dir_name" | sed 's/^-/\//' | sed 's/-/\//g')
+
+    # If the exact path exists, use its basename
+    if [[ -d "$candidate" ]]; then
+        basename "$candidate"
+        return 0
+    fi
+
+    # Walk backwards to find the deepest existing parent, then take the
+    # remainder as the project name. E.g. for /home/user/exp/claude-code:
+    # /home/user/exp exists -> project = "claude-code" (with / re-joined as -)
+    local parts
+    IFS='/' read -ra parts <<< "$candidate"
+    local i
+    for (( i=${#parts[@]}-1; i>=1; i-- )); do
+        local parent_path
+        parent_path=$(printf '%s/' "${parts[@]:0:i}" | sed 's|/$||')
+        if [[ -d "$parent_path" ]]; then
+            local remaining="${parts[*]:i}"
+            echo "${remaining// /-}"
+            return 0
+        fi
+    done
+
+    # Fallback: last component of the dash-separated name
+    echo "$dir_name" | rev | cut -d'-' -f1 | rev
 }
 
 # Get the full project path from a directory name
+# Note: this is a best-effort reconstruction since the encoding is lossy
+# (dashes in directory names are indistinguishable from path separators).
 episodic_project_path_from_dir() {
     local dir_name="$1"
-    echo "$dir_name" | sed 's/^-//' | tr '-' '/'
+    echo "$dir_name" | sed 's/^-/\//' | sed 's/-/\//g'
+}
+
+# Derive project name from CWD (preferred when CWD is available)
+episodic_project_from_cwd() {
+    basename "${CWD:-$(pwd)}"
 }
 
 # Knowledge repo configuration

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -9,7 +9,7 @@ echo ""
 
 passed=0
 failed=0
-tests=("test-init" "test-archive" "test-query" "test-roundtrip" "test-knowledge" "test-synthesize" "test-index")
+tests=("test-project-name" "test-init" "test-archive" "test-query" "test-roundtrip" "test-knowledge" "test-synthesize" "test-index")
 
 for test in "${tests[@]}"; do
     if bash "$SCRIPT_DIR/$test.sh"; then

--- a/tests/test-project-name.sh
+++ b/tests/test-project-name.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# test-project-name.sh: Verify project name derivation handles dashes correctly
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export EPISODIC_DB="/tmp/episodic-test-$$.db"
+export EPISODIC_LOG="/tmp/episodic-test-$$.log"
+export EPISODIC_ARCHIVE_DIR="/tmp/episodic-test-archives-$$"
+
+source "$SCRIPT_DIR/../lib/config.sh"
+
+# Use a base dir whose name has no dashes (avoids path ambiguity in tests)
+TMPBASE="/tmp/eptest$$"
+
+cleanup() {
+    rm -f "$EPISODIC_DB" "$EPISODIC_LOG"
+    rm -rf "$EPISODIC_ARCHIVE_DIR" "$TMPBASE"
+}
+trap cleanup EXIT
+
+echo "=== test-project-name ==="
+
+# Test 1: Simple project name (no dashes in final component)
+echo -n "  1. Simple project name... "
+mkdir -p "$TMPBASE/simple"
+result=$(episodic_project_from_path "-tmp-eptest$$-simple")
+if [[ "$result" == "simple" ]]; then
+    echo "PASS ($result)"
+else
+    echo "FAIL: expected 'simple', got '$result'"
+    exit 1
+fi
+
+# Test 2: Multi-dash project name (e.g., my-cool-app)
+echo -n "  2. Multi-dash project name... "
+mkdir -p "$TMPBASE/my-cool-app"
+result=$(episodic_project_from_path "-tmp-eptest$$-my-cool-app")
+if [[ "$result" == "my-cool-app" ]]; then
+    echo "PASS ($result)"
+else
+    echo "FAIL: expected 'my-cool-app', got '$result'"
+    exit 1
+fi
+
+# Test 3: Deeply nested project with dashes
+echo -n "  3. Deeply nested with dashes... "
+mkdir -p "$TMPBASE/sub/claude-code-episodic-memory"
+result=$(episodic_project_from_path "-tmp-eptest$$-sub-claude-code-episodic-memory")
+if [[ "$result" == "claude-code-episodic-memory" ]]; then
+    echo "PASS ($result)"
+else
+    echo "FAIL: expected 'claude-code-episodic-memory', got '$result'"
+    exit 1
+fi
+
+# Test 4: episodic_project_from_cwd uses basename
+echo -n "  4. episodic_project_from_cwd... "
+CWD="$TMPBASE/my-cool-app"
+result=$(episodic_project_from_cwd)
+if [[ "$result" == "my-cool-app" ]]; then
+    echo "PASS ($result)"
+else
+    echo "FAIL: expected 'my-cool-app', got '$result'"
+    exit 1
+fi
+
+# Test 5: Fallback when filesystem path doesn't exist
+echo -n "  5. Fallback for non-existent path... "
+result=$(episodic_project_from_path "-nonexistent-zzz-foo-bar")
+# Should fall back to last segment
+if [[ "$result" == "bar" ]]; then
+    echo "PASS ($result)"
+else
+    echo "FAIL: expected 'bar', got '$result'"
+    exit 1
+fi
+
+# Test 6: Exact match (directory exists at exact reconstructed path)
+echo -n "  6. Exact path match... "
+mkdir -p "$TMPBASE/exactmatch"
+result=$(episodic_project_from_path "-tmp-eptest$$-exactmatch")
+if [[ "$result" == "exactmatch" ]]; then
+    echo "PASS ($result)"
+else
+    echo "FAIL: expected 'exactmatch', got '$result'"
+    exit 1
+fi
+
+echo "=== test-project-name: ALL PASS ==="


### PR DESCRIPTION
## Summary
- `episodic_project_from_path` now walks the filesystem to resolve the actual directory boundary, correctly handling multi-dash project names like `claude-code-episodic-memory`
- Added `episodic_project_from_cwd` helper for reliable CWD-based naming
- `episodic-archive --previous` now passes CWD-derived project name to avoid lossy encoding
- Added `tests/test-project-name.sh` with 6 test cases

## Test plan
- [x] New test suite `test-project-name.sh` passes (6/6)
- [ ] Verify `episodic-archive --previous` stores correct project name for hyphenated directories
- [ ] Verify `episodic-context` matches archived sessions for same project

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)