### PR TITLE
Fix: sed -i '' macOS-only syntax (#2)

### DIFF
--- a/bin/episodic-knowledge-init
+++ b/bin/episodic-knowledge-init
@@ -17,8 +17,9 @@ episodic_knowledge_init "$REPO_URL"
 # Save repo URL to .env for persistence across sessions
 ENV_FILE="$EPISODIC_ROOT/.env"
 if [[ -f "$ENV_FILE" ]] && grep -q "EPISODIC_KNOWLEDGE_REPO" "$ENV_FILE" 2>/dev/null; then
-    # Update existing line
-    sed -i '' "s|^EPISODIC_KNOWLEDGE_REPO=.*|EPISODIC_KNOWLEDGE_REPO=\"$REPO_URL\"|" "$ENV_FILE"
+    # Update existing line (cross-platform: write to temp file and move)
+    local_tmp=$(mktemp)
+    sed "s|^EPISODIC_KNOWLEDGE_REPO=.*|EPISODIC_KNOWLEDGE_REPO=\"$REPO_URL\"|" "$ENV_FILE" > "$local_tmp" && mv "$local_tmp" "$ENV_FILE"
 else
     echo "EPISODIC_KNOWLEDGE_REPO=\"$REPO_URL\"" >> "$ENV_FILE"
 fi

--- a/tests/test-knowledge-init-env.sh
+++ b/tests/test-knowledge-init-env.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# test-knowledge-init-env.sh: Verify .env update works cross-platform (no macOS sed -i '')
+set -euo pipefail
+
+TMPDIR_TEST="/tmp/episodic-test-env-$$"
+cleanup() { rm -rf "$TMPDIR_TEST"; }
+trap cleanup EXIT
+
+echo "=== test-knowledge-init-env ==="
+
+mkdir -p "$TMPDIR_TEST"
+
+# Test 1: Update existing EPISODIC_KNOWLEDGE_REPO line
+echo -n "  1. Update existing .env line... "
+cat > "$TMPDIR_TEST/.env" <<'ENVFILE'
+EPISODIC_KNOWLEDGE_REPO="git@old.example.com:user/old.git"
+OTHER_VAR="keep-this"
+ENVFILE
+
+REPO_URL="git@github.com:user/new-repo.git"
+ENV_FILE="$TMPDIR_TEST/.env"
+
+# Replicate the logic from episodic-knowledge-init
+if [[ -f "$ENV_FILE" ]] && grep -q "EPISODIC_KNOWLEDGE_REPO" "$ENV_FILE" 2>/dev/null; then
+    local_tmp=$(mktemp)
+    sed "s|^EPISODIC_KNOWLEDGE_REPO=.*|EPISODIC_KNOWLEDGE_REPO=\"$REPO_URL\"|" "$ENV_FILE" > "$local_tmp" && mv "$local_tmp" "$ENV_FILE"
+fi
+
+if grep -q "git@github.com:user/new-repo.git" "$ENV_FILE" && grep -q 'OTHER_VAR="keep-this"' "$ENV_FILE"; then
+    echo "PASS"
+else
+    echo "FAIL"
+    cat "$ENV_FILE"
+    exit 1
+fi
+
+# Test 2: Append when line doesn't exist
+echo -n "  2. Append to .env when missing... "
+cat > "$TMPDIR_TEST/.env2" <<'ENVFILE'
+OTHER_VAR="something"
+ENVFILE
+
+ENV_FILE="$TMPDIR_TEST/.env2"
+if ! grep -q "EPISODIC_KNOWLEDGE_REPO" "$ENV_FILE" 2>/dev/null; then
+    echo "EPISODIC_KNOWLEDGE_REPO=\"$REPO_URL\"" >> "$ENV_FILE"
+fi
+
+if grep -q "EPISODIC_KNOWLEDGE_REPO=\"git@github.com:user/new-repo.git\"" "$ENV_FILE" && grep -q 'OTHER_VAR="something"' "$ENV_FILE"; then
+    echo "PASS"
+else
+    echo "FAIL"
+    cat "$ENV_FILE"
+    exit 1
+fi
+
+echo "=== test-knowledge-init-env: ALL PASS ==="


### PR DESCRIPTION
## Summary
- Replaced macOS-only `sed -i ''` with cross-platform temp file + mv approach in `bin/episodic-knowledge-init`
- Added `tests/test-knowledge-init-env.sh` covering update-in-place and append scenarios

## Test plan
- [x] `test-knowledge-init-env.sh` passes (2/2)
- [ ] Verify `.env` update works on both macOS and Linux

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)