### PR TITLE
Fix: config default mismatch between config.sh and synthesize.sh (#3)

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -10,7 +10,7 @@ EPISODIC_CLAUDE_PROJECTS="${EPISODIC_CLAUDE_PROJECTS:-$HOME/.claude/projects}"
 # Summary model: used for session summarization
 # Default: Opus 4.6. Override with any Anthropic model ID.
 # Examples: claude-opus-4-5-20251101, claude-sonnet-4-5-20250929, claude-haiku-4-5-20251001
-EPISODIC_SUMMARY_MODEL="${EPISODIC_SUMMARY_MODEL:-claude-opus-4-5-20251101}"
+EPISODIC_SUMMARY_MODEL="${EPISODIC_SUMMARY_MODEL:-claude-opus-4-6-20260205}"
 
 # Enable extended thinking for summary generation (true/false)
 # When enabled, the model thinks through the session before summarizing.
@@ -21,7 +21,7 @@ EPISODIC_SUMMARY_THINKING="${EPISODIC_SUMMARY_THINKING:-true}"
 EPISODIC_SUMMARY_THINKING_BUDGET="${EPISODIC_SUMMARY_THINKING_BUDGET:-10000}"
 
 # Skill synthesis model
-EPISODIC_OPUS_MODEL="${EPISODIC_OPUS_MODEL:-claude-opus-4-5-20251101}"
+EPISODIC_OPUS_MODEL="${EPISODIC_OPUS_MODEL:-claude-opus-4-6-20260205}"
 
 # Vision model for PDF/image OCR during document indexing
 EPISODIC_INDEX_VISION_MODEL="${EPISODIC_INDEX_VISION_MODEL:-claude-haiku-4-5-20251001}"

--- a/lib/synthesize.sh
+++ b/lib/synthesize.sh
@@ -7,8 +7,8 @@ source "$_EPISODIC_LIB_DIR/config.sh"
 source "$_EPISODIC_LIB_DIR/db.sh"
 source "$_EPISODIC_LIB_DIR/knowledge.sh"
 
-EPISODIC_OPUS_MODEL="${EPISODIC_OPUS_MODEL:-claude-opus-4-6-20260205}"
-EPISODIC_SYNTHESIZE_EVERY="${EPISODIC_SYNTHESIZE_EVERY:-5}"
+# All defaults (EPISODIC_OPUS_MODEL, EPISODIC_SYNTHESIZE_EVERY, etc.)
+# are set in config.sh — the single source of truth for configuration.
 
 # Generate a skill Markdown file with YAML frontmatter
 # Usage: episodic_synthesize_format_skill <name> <project> <session_ids_csv> <confidence> <body>

--- a/tests/test-config-defaults.sh
+++ b/tests/test-config-defaults.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# test-config-defaults.sh: Verify config defaults are consistent after sourcing all modules
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export EPISODIC_DB="/tmp/episodic-test-$$.db"
+export EPISODIC_LOG="/tmp/episodic-test-$$.log"
+
+# Unset any env overrides to test pure defaults
+unset EPISODIC_OPUS_MODEL EPISODIC_SUMMARY_MODEL EPISODIC_SYNTHESIZE_EVERY 2>/dev/null || true
+
+# Source config (the single source of truth) then synthesize (which used to re-declare)
+source "$SCRIPT_DIR/../lib/config.sh"
+source "$SCRIPT_DIR/../lib/synthesize.sh"
+
+cleanup() { rm -f "$EPISODIC_DB" "$EPISODIC_LOG"; }
+trap cleanup EXIT
+
+echo "=== test-config-defaults ==="
+
+# Test 1: EPISODIC_OPUS_MODEL should be opus 4.6
+echo -n "  1. EPISODIC_OPUS_MODEL default... "
+if [[ "$EPISODIC_OPUS_MODEL" == "claude-opus-4-6-20260205" ]]; then
+    echo "PASS ($EPISODIC_OPUS_MODEL)"
+else
+    echo "FAIL: expected claude-opus-4-6-20260205, got $EPISODIC_OPUS_MODEL"
+    exit 1
+fi
+
+# Test 2: EPISODIC_SUMMARY_MODEL should be opus 4.6
+echo -n "  2. EPISODIC_SUMMARY_MODEL default... "
+if [[ "$EPISODIC_SUMMARY_MODEL" == "claude-opus-4-6-20260205" ]]; then
+    echo "PASS ($EPISODIC_SUMMARY_MODEL)"
+else
+    echo "FAIL: expected claude-opus-4-6-20260205, got $EPISODIC_SUMMARY_MODEL"
+    exit 1
+fi
+
+# Test 3: EPISODIC_SYNTHESIZE_EVERY should be 2
+echo -n "  3. EPISODIC_SYNTHESIZE_EVERY default... "
+if [[ "$EPISODIC_SYNTHESIZE_EVERY" == "2" ]]; then
+    echo "PASS ($EPISODIC_SYNTHESIZE_EVERY)"
+else
+    echo "FAIL: expected 2, got $EPISODIC_SYNTHESIZE_EVERY"
+    exit 1
+fi
+
+# Test 4: Env override still works
+echo -n "  4. Env override takes precedence... "
+(
+    export EPISODIC_OPUS_MODEL="custom-model"
+    source "$SCRIPT_DIR/../lib/config.sh"
+    if [[ "$EPISODIC_OPUS_MODEL" == "custom-model" ]]; then
+        echo "PASS"
+    else
+        echo "FAIL: override not respected, got $EPISODIC_OPUS_MODEL"
+        exit 1
+    fi
+)
+
+echo "=== test-config-defaults: ALL PASS ==="


### PR DESCRIPTION
## Summary
- Updated `config.sh` model defaults to `claude-opus-4-6-20260205` (matching README documentation)
- Removed redundant `EPISODIC_OPUS_MODEL` and `EPISODIC_SYNTHESIZE_EVERY` re-declarations from `synthesize.sh` that were silently ignored
- Added `tests/test-config-defaults.sh` verifying defaults and env override behavior

## Test plan
- [x] `test-config-defaults.sh` passes (4/4)

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)