### PR TITLE
Fix: shasum not available on all Linux distros (#4)

### DIFF
--- a/lib/index.sh
+++ b/lib/index.sh
@@ -126,7 +126,11 @@ episodic_index_extract_text() {
 # Usage: episodic_index_content_hash <file_path>
 episodic_index_content_hash() {
     local file_path="$1"
-    shasum -a 256 < "$file_path" | cut -d' ' -f1
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum < "$file_path" | cut -d' ' -f1
+    else
+        shasum -a 256 < "$file_path" | cut -d' ' -f1
+    fi
 }
 
 # Index a single file into the documents table + FTS5

--- a/tests/test-content-hash.sh
+++ b/tests/test-content-hash.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# test-content-hash.sh: Verify content hashing works cross-platform
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export EPISODIC_DB="/tmp/episodic-test-$$.db"
+export EPISODIC_LOG="/tmp/episodic-test-$$.log"
+
+source "$SCRIPT_DIR/../lib/index.sh"
+
+TMPFILE="/tmp/episodic-hash-test-$$"
+cleanup() { rm -f "$TMPFILE" "$EPISODIC_DB" "$EPISODIC_LOG"; }
+trap cleanup EXIT
+
+echo "=== test-content-hash ==="
+
+# Test 1: Hash is a valid 64-char hex string
+echo -n "  1. Hash format... "
+echo "hello world" > "$TMPFILE"
+hash=$(episodic_index_content_hash "$TMPFILE")
+if [[ ${#hash} -eq 64 ]] && [[ "$hash" =~ ^[0-9a-f]+$ ]]; then
+    echo "PASS ($hash)"
+else
+    echo "FAIL: invalid hash format: '$hash'"
+    exit 1
+fi
+
+# Test 2: Same content produces same hash
+echo -n "  2. Deterministic... "
+hash2=$(episodic_index_content_hash "$TMPFILE")
+if [[ "$hash" == "$hash2" ]]; then
+    echo "PASS"
+else
+    echo "FAIL: hashes differ for same content"
+    exit 1
+fi
+
+# Test 3: Different content produces different hash
+echo -n "  3. Different content, different hash... "
+echo "different content" > "$TMPFILE"
+hash3=$(episodic_index_content_hash "$TMPFILE")
+if [[ "$hash" != "$hash3" ]]; then
+    echo "PASS"
+else
+    echo "FAIL: hashes should differ"
+    exit 1
+fi
+
+echo "=== test-content-hash: ALL PASS ==="


### PR DESCRIPTION
## Summary
- `episodic_index_content_hash` now tries `sha256sum` first (Linux standard), falls back to `shasum -a 256` (macOS)
- Added `tests/test-content-hash.sh` verifying hash format, determinism, and uniqueness

## Test plan
- [x] `test-content-hash.sh` passes (3/3)

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)