### PR TITLE
Fix: unescaped PROJECT in SQL queries in episodic-context (#6)

### DIFF
--- a/bin/episodic-context
+++ b/bin/episodic-context
@@ -39,6 +39,9 @@ if [[ -z "$PROJECT" ]]; then
     PROJECT=$(basename "${CWD:-$(pwd)}")
 fi
 
+# Escape for SQL single-quote interpolation
+SAFE_PROJECT="${PROJECT//\'/\'\'}"
+
 # Check DB exists
 if [[ ! -f "$EPISODIC_DB" ]]; then
     exit 0
@@ -160,7 +163,7 @@ if type episodic_knowledge_is_configured &>/dev/null && episodic_knowledge_is_co
 fi
 
 # Output indexed documents for project if available
-doc_count=$(sqlite3 "$EPISODIC_DB" "SELECT count(*) FROM documents WHERE project='$PROJECT';" 2>/dev/null || echo "0")
+doc_count=$(sqlite3 "$EPISODIC_DB" "SELECT count(*) FROM documents WHERE project='$SAFE_PROJECT';" 2>/dev/null || echo "0")
 if [[ "$doc_count" -gt 0 ]]; then
     echo ""
     echo "# Project Documents (${PROJECT})"
@@ -168,7 +171,7 @@ if [[ "$doc_count" -gt 0 ]]; then
     sqlite3 "$EPISODIC_DB" "
         SELECT file_name, title, file_type, file_size
         FROM documents
-        WHERE project='$PROJECT'
+        WHERE project='$SAFE_PROJECT'
         ORDER BY file_name;
     " 2>/dev/null | while IFS='|' read -r fname title ftype fsize; do
         size_kb=$(( ${fsize:-0} / 1024 ))

--- a/tests/test-sql-escape-context.sh
+++ b/tests/test-sql-escape-context.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# test-sql-escape-context.sh: Verify PROJECT is SQL-escaped in episodic-context
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DB="/tmp/episodic-test-$$.db"
+
+export EPISODIC_DB="$TEST_DB"
+export EPISODIC_LOG="/tmp/episodic-test-$$.log"
+export EPISODIC_ARCHIVE_DIR="/tmp/episodic-test-archives-$$"
+
+source "$SCRIPT_DIR/../lib/db.sh"
+
+cleanup() { rm -f "$TEST_DB" "$EPISODIC_LOG"; rm -rf "$EPISODIC_ARCHIVE_DIR"; }
+trap cleanup EXIT
+
+echo "=== test-sql-escape-context ==="
+
+episodic_db_init "$TEST_DB"
+
+# Test 1: Project name with a single quote doesn't break SQL
+echo -n "  1. Project with single quote in SQL... "
+# Insert a document with a tricky project name
+sqlite3 "$TEST_DB" "INSERT INTO documents (id, project, file_path, file_name, indexed_at) VALUES ('test:readme', 'o''reilly', '/tmp/test.md', 'test.md', datetime('now'));"
+
+# Simulate what episodic-context does with SAFE_PROJECT
+PROJECT="o'reilly"
+SAFE_PROJECT="${PROJECT//\'/\'\'}"
+count=$(sqlite3 "$TEST_DB" "SELECT count(*) FROM documents WHERE project='$SAFE_PROJECT';")
+if [[ "$count" == "1" ]]; then
+    echo "PASS"
+else
+    echo "FAIL: expected 1, got $count"
+    exit 1
+fi
+
+# Test 2: Normal project name still works
+echo -n "  2. Normal project name... "
+sqlite3 "$TEST_DB" "INSERT INTO documents (id, project, file_path, file_name, indexed_at) VALUES ('test2:readme', 'myproject', '/tmp/test2.md', 'test2.md', datetime('now'));"
+PROJECT="myproject"
+SAFE_PROJECT="${PROJECT//\'/\'\'}"
+count=$(sqlite3 "$TEST_DB" "SELECT count(*) FROM documents WHERE project='$SAFE_PROJECT';")
+if [[ "$count" == "1" ]]; then
+    echo "PASS"
+else
+    echo "FAIL: expected 1, got $count"
+    exit 1
+fi
+
+echo "=== test-sql-escape-context: ALL PASS ==="


### PR DESCRIPTION
## Summary
- Added `SAFE_PROJECT` with single-quote SQL escaping for all SQL interpolations in `episodic-context`
- Project names containing single quotes no longer break document listing queries

## Test plan
- [x] `test-sql-escape-context.sh` passes (2/2)

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)