### PR TITLE
Add SQLite busy_timeout to prevent SQLITE_BUSY under concurrency

### DIFF
--- a/bin/episodic-backfill
+++ b/bin/episodic-backfill
@@ -132,7 +132,7 @@ if [[ "$RETRY_SUMMARIES" == "true" ]]; then
         fi
 
         sleep "$DELAY"
-    done < <(sqlite3 "$EPISODIC_DB" "
+    done < <(episodic_db_exec "
         SELECT s.id, s.source_path, s.project
         FROM sessions s
         LEFT JOIN summaries sum ON sum.session_id = s.id
@@ -260,7 +260,7 @@ if [[ "$RUN_SYNTHESIS" == "true" && "$DRY_RUN" != "true" ]]; then
         else
             echo "  Skipping: $proj ($synth_count sessions, need $EPISODIC_SYNTHESIZE_EVERY)"
         fi
-    done < <(sqlite3 "$EPISODIC_DB" "
+    done < <(episodic_db_exec "
         SELECT project, count(*) as cnt
         FROM sessions
         GROUP BY project

--- a/bin/episodic-context
+++ b/bin/episodic-context
@@ -160,12 +160,12 @@ if type episodic_knowledge_is_configured &>/dev/null && episodic_knowledge_is_co
 fi
 
 # Output indexed documents for project if available
-doc_count=$(sqlite3 "$EPISODIC_DB" "SELECT count(*) FROM documents WHERE project='$PROJECT';" 2>/dev/null || echo "0")
+doc_count=$(episodic_db_exec "SELECT count(*) FROM documents WHERE project='$PROJECT';" 2>/dev/null || echo "0")
 if [[ "$doc_count" -gt 0 ]]; then
     echo ""
     echo "# Project Documents (${PROJECT})"
     echo ""
-    sqlite3 "$EPISODIC_DB" "
+    episodic_db_exec "
         SELECT file_name, title, file_type, file_size
         FROM documents
         WHERE project='$PROJECT'

--- a/bin/episodic-query
+++ b/bin/episodic-query
@@ -134,7 +134,7 @@ if [[ "$RECENT_MODE" == "true" ]]; then
     if [[ -n "$PROJECT" ]]; then
         results=$(episodic_db_recent "$PROJECT" "$LIMIT")
     else
-        results=$(sqlite3 -json "$EPISODIC_DB" "
+        results=$(episodic_db_query_json "
             SELECT s.id, s.project, s.created_at, s.first_prompt, s.git_branch,
                    s.duration_minutes, sum.summary, sum.topics, sum.decisions, sum.key_insights, sum.dead_ends
             FROM sessions s
@@ -160,7 +160,7 @@ fi
 # Docs-only mode: search only documents
 if [[ "$DOCS_ONLY" == "true" ]]; then
     query_escaped="${QUERY//\'/\'\'}"
-    doc_results=$(sqlite3 -json "$EPISODIC_DB" "
+    doc_results=$(episodic_db_query_json "
         SELECT d.id, d.project, d.file_path, d.file_name, d.title, d.file_type,
                d.indexed_at, d.file_size, d.extraction_method,
                snippet(documents_fts, 4, '>>>', '<<<', '...', 30) as snippet, rank
@@ -181,7 +181,7 @@ fi
 
 # FTS5 session search
 if [[ -n "$PROJECT" ]]; then
-    results=$(sqlite3 -json "$EPISODIC_DB" "
+    results=$(episodic_db_query_json "
         SELECT s.id, s.project, s.created_at, s.first_prompt, s.git_branch,
                s.duration_minutes, sum.summary, sum.topics, sum.decisions,
                sum.key_insights, sum.dead_ends, rank
@@ -205,7 +205,7 @@ fi
 # Also search documents and append results (unless --json mode)
 if [[ "$JSON_OUTPUT" != "true" ]]; then
     query_escaped="${QUERY//\'/\'\'}"
-    doc_results=$(sqlite3 -json "$EPISODIC_DB" "
+    doc_results=$(episodic_db_query_json "
         SELECT d.id, d.project, d.file_path, d.file_name, d.title, d.file_type,
                d.indexed_at, d.file_size, d.extraction_method,
                snippet(documents_fts, 4, '>>>', '<<<', '...', 30) as snippet, rank

--- a/lib/index.sh
+++ b/lib/index.sh
@@ -11,7 +11,7 @@ episodic_db_init_documents() {
     local db="${1:-$EPISODIC_DB}"
     mkdir -p "$(dirname "$db")"
 
-    sqlite3 "$db" <<'SQL'
+    episodic_db_exec_multi "$db" <<'SQL'
 CREATE TABLE IF NOT EXISTS documents (
     id TEXT PRIMARY KEY,
     project TEXT NOT NULL,
@@ -32,9 +32,9 @@ SQL
 
     # FTS5 table needs special handling
     local fts_exists
-    fts_exists=$(sqlite3 "$db" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='documents_fts';")
+    fts_exists=$(episodic_db_exec "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='documents_fts';" "$db")
     if [[ "$fts_exists" == "0" ]]; then
-        sqlite3 "$db" <<'SQL'
+        episodic_db_exec_multi "$db" <<'SQL'
 CREATE VIRTUAL TABLE documents_fts USING fts5(
     doc_id UNINDEXED,
     project,
@@ -159,7 +159,7 @@ episodic_index_file() {
 
     # Check if already indexed with same hash
     local existing_hash
-    existing_hash=$(sqlite3 "$db" "SELECT content_hash FROM documents WHERE id='${doc_id//\'/\'\'}';" 2>/dev/null || true)
+    existing_hash=$(episodic_db_exec "SELECT content_hash FROM documents WHERE id='${doc_id//\'/\'\'}';" "$db" 2>/dev/null || true)
     if [[ "$existing_hash" == "$content_hash" ]]; then
         episodic_log "INFO" "Skipping unchanged file: $file_path"
         return 0
@@ -221,7 +221,7 @@ episodic_index_file() {
     local safe_text="${extracted_text//\'/\'\'}"
 
     # Insert/replace into documents table
-    sqlite3 "$db" <<SQL
+    episodic_db_exec_multi "$db" <<SQL
 INSERT OR REPLACE INTO documents (
     id, project, file_path, file_name, title, file_type,
     file_size, content_hash, extracted_text, extraction_method, indexed_at
@@ -301,7 +301,7 @@ episodic_index_search() {
     # Escape single quotes in query
     query="${query//\'/\'\'}"
 
-    sqlite3 -json "$db" <<SQL
+    episodic_db_query_json "
 SELECT d.id, d.project, d.file_path, d.file_name, d.title, d.file_type,
        d.indexed_at, d.file_size, d.extraction_method,
        snippet(documents_fts, 4, '>>>', '<<<', '...', 30) as snippet, rank
@@ -309,8 +309,7 @@ FROM documents_fts fts
 JOIN documents d ON d.id = fts.doc_id
 WHERE documents_fts MATCH '$query'
 ORDER BY rank
-LIMIT $limit;
-SQL
+LIMIT $limit;" "$db"
 }
 
 # Return JSON with index stats
@@ -319,16 +318,16 @@ episodic_index_stats() {
     local db="${EPISODIC_DB}"
 
     local total
-    total=$(sqlite3 "$db" "SELECT count(*) FROM documents;")
+    total=$(episodic_db_exec "SELECT count(*) FROM documents;" "$db")
 
     local by_project
-    by_project=$(sqlite3 -json "$db" "SELECT project, count(*) as count FROM documents GROUP BY project;")
+    by_project=$(episodic_db_query_json "SELECT project, count(*) as count FROM documents GROUP BY project;" "$db")
 
     local by_type
-    by_type=$(sqlite3 -json "$db" "SELECT file_type, count(*) as count FROM documents GROUP BY file_type;")
+    by_type=$(episodic_db_query_json "SELECT file_type, count(*) as count FROM documents GROUP BY file_type;" "$db")
 
     local total_size
-    total_size=$(sqlite3 "$db" "SELECT coalesce(sum(file_size), 0) FROM documents;")
+    total_size=$(episodic_db_exec "SELECT coalesce(sum(file_size), 0) FROM documents;" "$db")
 
     jq -n \
         --argjson total "$total" \
@@ -349,13 +348,13 @@ episodic_index_cleanup() {
     local safe_project="${project//\'/\'\'}"
 
     local doc_ids_paths
-    doc_ids_paths=$(sqlite3 "$db" "SELECT id, file_path FROM documents WHERE project='$safe_project';")
+    doc_ids_paths=$(episodic_db_exec "SELECT id, file_path FROM documents WHERE project='$safe_project';" "$db")
 
     while IFS='|' read -r doc_id file_path; do
         [[ -z "$doc_id" ]] && continue
         if [[ ! -f "$file_path" ]]; then
             local safe_id="${doc_id//\'/\'\'}"
-            sqlite3 "$db" <<SQL
+            episodic_db_exec_multi "$db" <<SQL
 DELETE FROM documents WHERE id = '$safe_id';
 DELETE FROM documents_fts WHERE doc_id = '$safe_id';
 SQL

--- a/tests/test-busy-timeout.sh
+++ b/tests/test-busy-timeout.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Test: SQLite busy_timeout is applied via wrapper functions
+set -euo pipefail
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export EPISODIC_DATA_DIR="$TEST_DIR"
+export EPISODIC_DB="$TEST_DIR/test.db"
+export EPISODIC_LOG_FILE="$TEST_DIR/test.log"
+export EPISODIC_KNOWLEDGE_DIR="$TEST_DIR/knowledge"
+export EPISODIC_BUSY_TIMEOUT=3000
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/db.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  ✓ $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  ✗ $desc: expected '$expected', got '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Test: SQLite busy_timeout ==="
+
+# Test 1: episodic_db_exec sets busy_timeout and runs queries
+echo ""
+echo "Test 1: episodic_db_exec works with busy_timeout"
+episodic_db_init "$EPISODIC_DB" >/dev/null 2>&1
+result=$(episodic_db_exec "SELECT count(*) FROM sessions;" "$EPISODIC_DB")
+assert_eq "Session count returns 0" "0" "$result"
+
+# Test 2: episodic_db_exec_multi works with heredoc
+echo ""
+echo "Test 2: episodic_db_exec_multi handles multi-statement blocks"
+episodic_db_exec_multi "$EPISODIC_DB" <<'SQL'
+INSERT INTO sessions (id, project, created_at) VALUES ('t1', 'testproj', datetime('now'));
+INSERT INTO sessions (id, project, created_at) VALUES ('t2', 'testproj', datetime('now'));
+SQL
+result=$(episodic_db_exec "SELECT count(*) FROM sessions;" "$EPISODIC_DB")
+assert_eq "Two rows inserted via exec_multi" "2" "$result"
+
+# Test 3: episodic_db_query_json returns valid JSON
+echo ""
+echo "Test 3: episodic_db_query_json returns JSON"
+json_result=$(episodic_db_query_json "SELECT id, project FROM sessions ORDER BY id;" "$EPISODIC_DB")
+id_count=$(echo "$json_result" | jq length)
+assert_eq "JSON result has 2 entries" "2" "$id_count"
+first_id=$(echo "$json_result" | jq -r '.[0].id')
+assert_eq "First id is t1" "t1" "$first_id"
+
+# Test 4: Custom EPISODIC_BUSY_TIMEOUT is respected
+echo ""
+echo "Test 4: Custom busy_timeout value is used"
+# We verify by checking that the PRAGMA is sent (indirectly by ensuring it doesn't error)
+export EPISODIC_BUSY_TIMEOUT=100
+result=$(episodic_db_exec "SELECT count(*) FROM sessions;" "$EPISODIC_DB")
+assert_eq "Query works with custom timeout" "2" "$result"
+
+# Test 5: No raw sqlite3 calls remain in lib/ and bin/ (outside wrappers and tests)
+echo ""
+echo "Test 5: No raw sqlite3 calls outside wrappers"
+raw_calls=$(grep -rn 'sqlite3 ' "$SCRIPT_DIR/../lib/" "$SCRIPT_DIR/../bin/" 2>/dev/null \
+    | grep -v 'episodic_db_exec\|episodic_db_query_json\|episodic_db_exec_multi' \
+    | grep -v '# .*sqlite3' \
+    | grep -v 'command -v sqlite3' \
+    | grep -v 'sqlite3 --version' \
+    | grep -v 'db\.sh:.*sqlite3 ' \
+    || true)
+if [[ -z "$raw_calls" ]]; then
+    echo "  ✓ No raw sqlite3 calls found outside wrappers"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ Found raw sqlite3 calls:"
+    echo "$raw_calls"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Adds three wrapper functions (`episodic_db_exec`, `episodic_db_query_json`, `episodic_db_exec_multi`) to `lib/db.sh` that set `.timeout` before every SQLite operation
- Converts all raw `sqlite3` calls in `lib/` and `bin/` to use these wrappers
- Default timeout is 5 seconds (configurable via `EPISODIC_BUSY_TIMEOUT` env var)
- Uses `.timeout` dot-command instead of `PRAGMA busy_timeout` to avoid output leaking into query results

## Test plan
- [x] New `tests/test-busy-timeout.sh` with 6 tests covering all wrappers and verifying no raw calls remain
- [x] All 7 existing test suites pass without modification

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)