### PR TITLE
Centralize SQL escaping into episodic_sql_escape function

### DIFF
--- a/bin/episodic-query
+++ b/bin/episodic-query
@@ -159,7 +159,7 @@ fi
 
 # Docs-only mode: search only documents
 if [[ "$DOCS_ONLY" == "true" ]]; then
-    query_escaped="${QUERY//\'/\'\'}"
+    query_escaped=$(episodic_sql_escape "$QUERY")
     doc_results=$(sqlite3 -json "$EPISODIC_DB" "
         SELECT d.id, d.project, d.file_path, d.file_name, d.title, d.file_type,
                d.indexed_at, d.file_size, d.extraction_method,
@@ -188,7 +188,7 @@ if [[ -n "$PROJECT" ]]; then
         FROM sessions_fts fts
         JOIN sessions s ON s.id = fts.session_id
         JOIN summaries sum ON sum.session_id = fts.session_id
-        WHERE sessions_fts MATCH '${QUERY//\'/\'\'}' AND s.project = '${PROJECT//\'/\'\'}'
+        WHERE sessions_fts MATCH '$(episodic_sql_escape "$QUERY")' AND s.project = '$(episodic_sql_escape "$PROJECT")'
         ORDER BY rank
         LIMIT $LIMIT;
     ")
@@ -204,7 +204,7 @@ fi
 
 # Also search documents and append results (unless --json mode)
 if [[ "$JSON_OUTPUT" != "true" ]]; then
-    query_escaped="${QUERY//\'/\'\'}"
+    query_escaped=$(episodic_sql_escape "$QUERY")
     doc_results=$(sqlite3 -json "$EPISODIC_DB" "
         SELECT d.id, d.project, d.file_path, d.file_name, d.title, d.file_type,
                d.indexed_at, d.file_size, d.extraction_method,

--- a/lib/index.sh
+++ b/lib/index.sh
@@ -159,7 +159,7 @@ episodic_index_file() {
 
     # Check if already indexed with same hash
     local existing_hash
-    existing_hash=$(sqlite3 "$db" "SELECT content_hash FROM documents WHERE id='${doc_id//\'/\'\'}';" 2>/dev/null || true)
+    existing_hash=$(sqlite3 "$db" "SELECT content_hash FROM documents WHERE id='$(episodic_sql_escape "$doc_id")';" 2>/dev/null || true)
     if [[ "$existing_hash" == "$content_hash" ]]; then
         episodic_log "INFO" "Skipping unchanged file: $file_path"
         return 0
@@ -212,13 +212,13 @@ episodic_index_file() {
         csv) extraction_method="csv-head" ;;
     esac
 
-    # Escape single quotes for SQL
-    local safe_id="${doc_id//\'/\'\'}"
-    local safe_project="${project//\'/\'\'}"
-    local safe_file_path="${file_path//\'/\'\'}"
-    local safe_file_name="${file_name//\'/\'\'}"
-    local safe_title="${title//\'/\'\'}"
-    local safe_text="${extracted_text//\'/\'\'}"
+    local safe_id safe_project safe_file_path safe_file_name safe_title safe_text
+    safe_id=$(episodic_sql_escape "$doc_id")
+    safe_project=$(episodic_sql_escape "$project")
+    safe_file_path=$(episodic_sql_escape "$file_path")
+    safe_file_name=$(episodic_sql_escape "$file_name")
+    safe_title=$(episodic_sql_escape "$title")
+    safe_text=$(episodic_sql_escape "$extracted_text")
 
     # Insert/replace into documents table
     sqlite3 "$db" <<SQL
@@ -298,8 +298,7 @@ episodic_index_search() {
     local limit="${2:-10}"
     local db="${EPISODIC_DB}"
 
-    # Escape single quotes in query
-    query="${query//\'/\'\'}"
+    query=$(episodic_sql_escape "$query")
 
     sqlite3 -json "$db" <<SQL
 SELECT d.id, d.project, d.file_path, d.file_name, d.title, d.file_type,
@@ -345,8 +344,8 @@ episodic_index_cleanup() {
     local db="${EPISODIC_DB}"
     local removed=0
 
-    # Escape single quotes
-    local safe_project="${project//\'/\'\'}"
+    local safe_project
+    safe_project=$(episodic_sql_escape "$project")
 
     local doc_ids_paths
     doc_ids_paths=$(sqlite3 "$db" "SELECT id, file_path FROM documents WHERE project='$safe_project';")
@@ -354,7 +353,8 @@ episodic_index_cleanup() {
     while IFS='|' read -r doc_id file_path; do
         [[ -z "$doc_id" ]] && continue
         if [[ ! -f "$file_path" ]]; then
-            local safe_id="${doc_id//\'/\'\'}"
+            local safe_id
+            safe_id=$(episodic_sql_escape "$doc_id")
             sqlite3 "$db" <<SQL
 DELETE FROM documents WHERE id = '$safe_id';
 DELETE FROM documents_fts WHERE doc_id = '$safe_id';

--- a/tests/test-sql-escape.sh
+++ b/tests/test-sql-escape.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Test: Centralized SQL escaping function
+set -euo pipefail
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export EPISODIC_DATA_DIR="$TEST_DIR"
+export EPISODIC_DB="$TEST_DIR/test.db"
+export EPISODIC_LOG="$TEST_DIR/test.log"
+export EPISODIC_KNOWLEDGE_DIR="$TEST_DIR/knowledge"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/db.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  ✓ $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  ✗ $desc: expected '$expected', got '$actual'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Test: SQL escape function ==="
+
+# Test 1: Normal string unchanged
+echo ""
+echo "Test 1: Normal string passes through"
+result=$(episodic_sql_escape "hello world")
+assert_eq "No quotes unchanged" "hello world" "$result"
+
+# Test 2: Single quotes are doubled
+echo ""
+echo "Test 2: Single quotes escaped"
+result=$(episodic_sql_escape "O'Brien")
+assert_eq "Single quote doubled" "O''Brien" "$result"
+
+# Test 3: Multiple single quotes
+echo ""
+echo "Test 3: Multiple quotes"
+result=$(episodic_sql_escape "it's a 'test' isn't it")
+assert_eq "All quotes doubled" "it''s a ''test'' isn''t it" "$result"
+
+# Test 4: Empty string
+echo ""
+echo "Test 4: Empty string"
+result=$(episodic_sql_escape "")
+assert_eq "Empty string ok" "" "$result"
+
+# Test 5: String with no special chars
+echo ""
+echo "Test 5: No special chars"
+result=$(episodic_sql_escape "abc 123 def")
+assert_eq "Plain string ok" "abc 123 def" "$result"
+
+# Test 6: Data with quotes can be inserted and retrieved
+echo ""
+echo "Test 6: Round-trip with quotes in data"
+episodic_db_init "$EPISODIC_DB" >/dev/null 2>&1
+safe_prompt=$(episodic_sql_escape "Fix the O'Brien bug in user's code")
+sqlite3 "$EPISODIC_DB" "INSERT INTO sessions (id, project, created_at, first_prompt) VALUES ('t1', 'test', datetime('now'), '$safe_prompt');"
+retrieved=$(sqlite3 "$EPISODIC_DB" "SELECT first_prompt FROM sessions WHERE id='t1';")
+assert_eq "Data round-trips correctly" "Fix the O'Brien bug in user's code" "$retrieved"
+
+# Test 7: No inline escaping remains in lib/ (except the function definition)
+echo ""
+echo "Test 7: No inline escaping patterns in lib/ or bin/"
+# Look for the raw pattern: //\'/ which is the bash single-quote escape idiom
+inline_matches=$(grep -rn "//\\\\'" "$SCRIPT_DIR/../lib/" "$SCRIPT_DIR/../bin/" 2>/dev/null \
+    | grep -v 'episodic_sql_escape' \
+    | grep -v "printf " \
+    || true)
+if [[ -z "$inline_matches" ]]; then
+    echo "  ✓ No inline escaping outside function"
+    PASS=$((PASS + 1))
+else
+    echo "  ✗ Found inline escaping:"
+    echo "$inline_matches"
+    FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Adds `episodic_sql_escape()` function in `lib/db.sh` that doubles single quotes for safe SQL string interpolation
- Replaces ~25 inline `${var//\'/\'\'}` patterns across `lib/db.sh`, `lib/index.sh`, and `bin/episodic-query`
- Single point of maintenance for escaping logic, reducing risk of missed escapes

## Test plan
- [x] New `tests/test-sql-escape.sh` with 7 tests covering normal strings, quotes, empty strings, data round-trip, and verification that no inline patterns remain
- [x] All 7 existing test suites pass

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)