### PR TITLE
Use temp files for large text in SQL insert operations

### DIFF
--- a/lib/db.sh
+++ b/lib/db.sh
@@ -184,24 +184,32 @@ episodic_db_insert_summary() {
     first_prompt="${first_prompt//\'/\'\'}"
     project="${project//\'/\'\'}"
 
-    sqlite3 "$db" <<SQL
-INSERT OR REPLACE INTO summaries (
-    session_id, topics, decisions, dead_ends, artifacts_created,
-    key_insights, summary, generated_at, model
-) VALUES (
-    '$session_id', '$topics_json', '$decisions_json', '$dead_ends_json',
-    '$artifacts_json', '$insights_json', '$summary_text', datetime('now'), '$model'
-);
+    # Write SQL to temp file to avoid bash variable size limits.
+    # Summary text and first_prompt can be substantial; writing through
+    # printf to a file bypasses heredoc expansion limitations.
+    local sql_file
+    sql_file=$(mktemp)
+    trap 'rm -f "$sql_file"' RETURN
 
-DELETE FROM sessions_fts WHERE session_id = '$session_id';
-INSERT INTO sessions_fts (
-    session_id, project, topics, decisions, dead_ends,
-    key_insights, summary, first_prompt
-) VALUES (
-    '$session_id', '$project', '$topics', '$decisions', '$dead_ends',
-    '$key_insights', '$summary_text', '$first_prompt'
-);
-SQL
+    {
+        printf "INSERT OR REPLACE INTO summaries (\n"
+        printf "    session_id, topics, decisions, dead_ends, artifacts_created,\n"
+        printf "    key_insights, summary, generated_at, model\n"
+        printf ") VALUES (\n"
+        printf "    '%s', '%s', '%s', '%s',\n" "$session_id" "$topics_json" "$decisions_json" "$dead_ends_json"
+        printf "    '%s', '%s', '%s', datetime('now'), '%s'\n" "$artifacts_json" "$insights_json" "$summary_text" "$model"
+        printf ");\n\n"
+        printf "DELETE FROM sessions_fts WHERE session_id = '%s';\n" "$session_id"
+        printf "INSERT INTO sessions_fts (\n"
+        printf "    session_id, project, topics, decisions, dead_ends,\n"
+        printf "    key_insights, summary, first_prompt\n"
+        printf ") VALUES (\n"
+        printf "    '%s', '%s', '%s', '%s', '%s',\n" "$session_id" "$project" "$topics" "$decisions" "$dead_ends"
+        printf "    '%s', '%s', '%s'\n" "$key_insights" "$summary_text" "$first_prompt"
+        printf ");\n"
+    } > "$sql_file"
+
+    sqlite3 "$db" < "$sql_file"
 }
 
 # Update archive log

--- a/lib/index.sh
+++ b/lib/index.sh
@@ -218,23 +218,30 @@ episodic_index_file() {
     local safe_file_path="${file_path//\'/\'\'}"
     local safe_file_name="${file_name//\'/\'\'}"
     local safe_title="${title//\'/\'\'}"
-    local safe_text="${extracted_text//\'/\'\'}"
 
-    # Insert/replace into documents table
-    sqlite3 "$db" <<SQL
-INSERT OR REPLACE INTO documents (
-    id, project, file_path, file_name, title, file_type,
-    file_size, content_hash, extracted_text, extraction_method, indexed_at
-) VALUES (
-    '$safe_id', '$safe_project', '$safe_file_path', '$safe_file_name',
-    '$safe_title', '$file_type', $file_size, '$content_hash',
-    '$safe_text', '$extraction_method', datetime('now')
-);
+    # Write SQL to temp file to avoid bash variable size limits on large text.
+    # The extracted_text can be up to 100KB; heredoc expansion through bash
+    # is fragile at that size. Writing to a file bypasses this.
+    local sql_file
+    sql_file=$(mktemp)
+    trap 'rm -f "$sql_file"' RETURN
 
-DELETE FROM documents_fts WHERE doc_id = '$safe_id';
-INSERT INTO documents_fts (doc_id, project, file_name, title, extracted_text)
-VALUES ('$safe_id', '$safe_project', '$safe_file_name', '$safe_title', '$safe_text');
-SQL
+    {
+        printf "INSERT OR REPLACE INTO documents (\n"
+        printf "    id, project, file_path, file_name, title, file_type,\n"
+        printf "    file_size, content_hash, extracted_text, extraction_method, indexed_at\n"
+        printf ") VALUES (\n"
+        printf "    '%s', '%s', '%s', '%s',\n" "$safe_id" "$safe_project" "$safe_file_path" "$safe_file_name"
+        printf "    '%s', '%s', %s, '%s',\n" "$safe_title" "$file_type" "$file_size" "$content_hash"
+        printf "    '%s', '%s', datetime('now')\n" "${extracted_text//\'/\'\'}" "$extraction_method"
+        printf ");\n\n"
+        printf "DELETE FROM documents_fts WHERE doc_id = '%s';\n" "$safe_id"
+        printf "INSERT INTO documents_fts (doc_id, project, file_name, title, extracted_text)\n"
+        printf "VALUES ('%s', '%s', '%s', '%s', '%s');\n" \
+            "$safe_id" "$safe_project" "$safe_file_name" "$safe_title" "${extracted_text//\'/\'\'}"
+    } > "$sql_file"
+
+    sqlite3 "$db" < "$sql_file"
 
     episodic_log "INFO" "Indexed: $doc_id ($file_type, $file_size bytes)"
 }

--- a/tests/test-large-text-sql.sh
+++ b/tests/test-large-text-sql.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Test: Large text handling via temp files in SQL operations
+set -euo pipefail
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export EPISODIC_DATA_DIR="$TEST_DIR"
+export EPISODIC_DB="$TEST_DIR/test.db"
+export EPISODIC_LOG="$TEST_DIR/test.log"
+export EPISODIC_KNOWLEDGE_DIR="$TEST_DIR/knowledge"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/db.sh"
+source "$SCRIPT_DIR/../lib/index.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  ✓ $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "  ✗ $desc: expected '${expected:0:60}...', got '${actual:0:60}...'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+echo "=== Test: Large text SQL operations ==="
+
+episodic_db_init "$EPISODIC_DB" >/dev/null 2>&1
+
+# Test 1: Insert and retrieve a large summary via temp file
+echo ""
+echo "Test 1: Large summary text round-trip"
+# Create a session first
+sqlite3 "$EPISODIC_DB" "INSERT INTO sessions (id, project, created_at, first_prompt) VALUES ('big1', 'testproj', datetime('now'), 'test prompt');"
+
+# Generate a 50KB summary text
+large_summary=""
+for i in $(seq 1 500); do
+    large_summary+="This is line $i of a very large summary text that tests the temp file SQL path. "
+done
+large_summary_len=${#large_summary}
+echo "  (generated ${large_summary_len} chars of summary text)"
+
+summary_json=$(jq -n --arg sum "$large_summary" '{
+    topics: ["large-text-test", "temp-file-sql"],
+    decisions: ["use temp files for large SQL"],
+    dead_ends: [],
+    artifacts_created: [],
+    key_insights: ["temp files bypass bash limits"],
+    summary: $sum
+}')
+
+episodic_db_insert_summary "big1" "$summary_json" "test-model"
+retrieved=$(sqlite3 "$EPISODIC_DB" "SELECT length(summary) FROM summaries WHERE session_id='big1';")
+assert_eq "Summary stored with correct length" "$large_summary_len" "$retrieved"
+
+# Test 2: Large document text via index_file temp file path
+echo ""
+echo "Test 2: Large document indexing round-trip"
+mkdir -p "$TEST_DIR/knowledge/testproj"
+large_doc="$TEST_DIR/knowledge/testproj/large-doc.md"
+
+# Generate a 80KB document
+{
+    echo "# Large Test Document"
+    echo ""
+    for i in $(seq 1 1000); do
+        echo "Section $i: This is a paragraph of text in a large document that tests the temp file path for SQL insertion. It contains enough content to exceed typical heredoc limits."
+    done
+} > "$large_doc"
+
+large_doc_size=$(wc -c < "$large_doc" | tr -d ' ')
+echo "  (created ${large_doc_size} byte test document)"
+
+episodic_index_file "$large_doc" "testproj"
+stored_size=$(sqlite3 "$EPISODIC_DB" "SELECT length(extracted_text) FROM documents WHERE project='testproj';")
+assert_eq "Document text stored (non-zero length)" "true" "$([[ "$stored_size" -gt 1000 ]] && echo true || echo false)"
+
+# Test 3: Text with single quotes in large payload
+echo ""
+echo "Test 3: Large text with quotes"
+sqlite3 "$EPISODIC_DB" "INSERT INTO sessions (id, project, created_at, first_prompt) VALUES ('big2', 'testproj', datetime('now'), 'another test');"
+
+quote_text="It's a test with O'Brien's code that can't fail. "
+large_quote_text=""
+for i in $(seq 1 500); do
+    large_quote_text+="$quote_text"
+done
+
+quote_json=$(jq -n --arg sum "$large_quote_text" '{
+    topics: ["quote-test"],
+    decisions: [],
+    dead_ends: [],
+    artifacts_created: [],
+    key_insights: [],
+    summary: $sum
+}')
+
+episodic_db_insert_summary "big2" "$quote_json" "test-model"
+retrieved_len=$(sqlite3 "$EPISODIC_DB" "SELECT length(summary) FROM summaries WHERE session_id='big2';")
+expected_len=${#large_quote_text}
+assert_eq "Quoted text stored with correct length" "$expected_len" "$retrieved_len"
+
+# Test 4: Temp files are cleaned up
+echo ""
+echo "Test 4: No temp files leaked"
+# Count temp files before and after an operation
+before=$(ls /tmp/tmp.* 2>/dev/null | wc -l || echo 0)
+sqlite3 "$EPISODIC_DB" "INSERT INTO sessions (id, project, created_at, first_prompt) VALUES ('big3', 'testproj', datetime('now'), 'temp test');"
+small_json='{"topics":["t"],"decisions":[],"dead_ends":[],"artifacts_created":[],"key_insights":[],"summary":"small"}'
+episodic_db_insert_summary "big3" "$small_json" "test-model"
+after=$(ls /tmp/tmp.* 2>/dev/null | wc -l || echo 0)
+# Should not have accumulated temp files (trap RETURN cleans them)
+assert_eq "No temp file leak" "true" "$([[ "$after" -le "$((before + 0))" ]] && echo true || echo false)"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Replaced heredoc-based SQL construction with `printf` to temp files in `episodic_db_insert_summary` and `episodic_index_file`
- Large strings (document text up to 100KB, summaries) are now written to a temp file via `printf`, then piped to `sqlite3 < file` — avoiding bash heredoc expansion limits
- Temp files are automatically cleaned up via `trap RETURN`

## Test plan
- [x] New `tests/test-large-text-sql.sh` with 4 tests: 40KB summary round-trip, 170KB document indexing, large text with quotes, temp file cleanup verification
- [x] All 7 existing test suites pass

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)