### PR TITLE
feat: swap summarize/reflect to headless claude -p + parallel-backfill hardening

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,6 @@
+{
+  "name": "pi-marketplace",
+  "owner": {"name": "theaichimera", "url": "https://github.com/theaichimera"},
+  "metadata": {"description": "Project Intelligence: Persistent learning system for Claude Code", "version": "1.0.0"},
+  "plugins": [{"name": "pi", "description": "Episodic memory, skill synthesis, reasoning progressions, behavioral patterns, activity intelligence.", "source": "./"}]
+}

--- a/bin/pi-analyze
+++ b/bin/pi-analyze
@@ -5,7 +5,16 @@
 set -euo pipefail
 
 BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$BIN_DIR/../lib/deep-dive.sh"
+# deep-dive.sh was archived in commit f3a222e but pi-analyze still needs it.
+# Fall back to archive copy if the canonical path is missing.
+if [[ -f "$BIN_DIR/../lib/deep-dive.sh" ]]; then
+    source "$BIN_DIR/../lib/deep-dive.sh"
+elif [[ -f "$BIN_DIR/../archive/lib/deep-dive.sh" ]]; then
+    source "$BIN_DIR/../archive/lib/deep-dive.sh"
+else
+    echo "ERROR: pi-analyze requires lib/deep-dive.sh (canonical or archive copy)." >&2
+    exit 1
+fi
 source "$BIN_DIR/../lib/progression.sh"
 [[ -f "$BIN_DIR/../lib/knowledge.sh" ]] && source "$BIN_DIR/../lib/knowledge.sh"
 

--- a/bin/pi-archive
+++ b/bin/pi-archive
@@ -223,6 +223,10 @@ while [[ $# -gt 0 ]]; do
             SKIP_SUMMARY=true
             shift
             ;;
+        --deep)
+            export EPISODIC_DEEP=1
+            shift
+            ;;
         --dry-run)
             DRY_RUN=true
             shift

--- a/bin/pi-backfill
+++ b/bin/pi-backfill
@@ -35,14 +35,19 @@ SKIP_SUMMARY=false
 DRY_RUN=false
 RETRY_SUMMARIES=false
 PROJECT_FILTER=""
+ID_PREFIX=""
+IDS_FILE=""
 LIMIT=0
 DELAY=0.5
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --no-summary) SKIP_SUMMARY=true; shift ;;
+        --deep) export EPISODIC_DEEP=1; shift ;;
         --retry-summaries) RETRY_SUMMARIES=true; shift ;;
         --project) PROJECT_FILTER="$2"; shift 2 ;;
+        --id-prefix) ID_PREFIX="$2"; shift 2 ;;
+        --ids-file) IDS_FILE="$2"; shift 2 ;;
         --dry-run) DRY_RUN=true; shift ;;
         --limit) LIMIT="$2"; shift 2 ;;
         --delay) DELAY="$2"; shift 2 ;;
@@ -65,12 +70,31 @@ if [[ "$RETRY_SUMMARIES" == "true" ]]; then
     succeeded=0
     still_failed=0
 
-    while IFS='|' read -r sid source_path project; do
+    while IFS='|' read -r sid source_path archive_path project; do
         [[ -n "$sid" ]] || continue
 
         # Apply project filter
         if [[ -n "$PROJECT_FILTER" && "$project" != *"$PROJECT_FILTER"* ]]; then
             continue
+        fi
+
+        # Apply id-prefix filter (for sharding parallel runs): "0-3" matches IDs starting 0/1/2/3
+        if [[ -n "$ID_PREFIX" ]]; then
+            if [[ "$ID_PREFIX" == *-* ]]; then
+                lo="${ID_PREFIX%-*}"; hi="${ID_PREFIX#*-}"
+                first="${sid:0:1}"
+                # Hex char comparison
+                if [[ ! "$first" =~ ^[$lo-$hi]$ ]]; then continue; fi
+            else
+                [[ "$sid" != "$ID_PREFIX"* ]] && continue
+            fi
+        fi
+
+        # Apply ids-file filter (LPT-balanced bins): only process IDs in the file
+        if [[ -n "$IDS_FILE" ]]; then
+            if ! grep -qxF "$sid" "$IDS_FILE" 2>/dev/null; then
+                continue
+            fi
         fi
 
         # Check limit
@@ -87,9 +111,15 @@ if [[ "$RETRY_SUMMARIES" == "true" ]]; then
             continue
         fi
 
+        # Fall back to archive_path if the original bucket file has been deleted
+        # (e.g. after bulk cleanup of ~/.claude/projects/ orphan buckets).
         if [[ ! -f "$source_path" ]]; then
-            echo "SKIP (source file missing)"
-            continue
+            if [[ -n "$archive_path" && -f "$archive_path" ]]; then
+                source_path="$archive_path"
+            else
+                echo "SKIP (source + archive both missing)"
+                continue
+            fi
         fi
 
         # Extract and summarize in a subshell to prevent set -e from killing the loop.
@@ -119,7 +149,7 @@ if [[ "$RETRY_SUMMARIES" == "true" ]]; then
                     echo "FAIL:summary"
                     exit 1
                 fi
-            ' 2>/dev/null
+            ' 2>>"${EPISODIC_BACKFILL_LOG:-/tmp/pi-backfill-stderr.log}"
         ); then
             case "$result" in
                 OK:*)
@@ -137,7 +167,7 @@ if [[ "$RETRY_SUMMARIES" == "true" ]]; then
 
         sleep "$DELAY"
     done < <(episodic_db_exec "
-        SELECT s.id, s.source_path, s.project
+        SELECT s.id, s.source_path, s.archive_path, s.project
         FROM sessions s
         LEFT JOIN summaries sum ON sum.session_id = s.id
         WHERE sum.session_id IS NULL

--- a/hooks/on-session-start.sh
+++ b/hooks/on-session-start.sh
@@ -4,6 +4,9 @@
 #
 # Supports both plugin mode (CLAUDE_PLUGIN_ROOT) and standalone install.
 
+# Recursion guard: skip when invoked from PI's own `claude -p` subprocess.
+[[ "${PI_SUBPROCESS:-0}" == "1" ]] && exit 0
+
 PI_ROOT="${CLAUDE_PLUGIN_ROOT:-${PI_ROOT:-${EPISODIC_ROOT:-$HOME/.claude/project-intelligence}}}"
 
 # Backward compat: check both pi-* and episodic-* script names

--- a/hooks/on-stop.sh
+++ b/hooks/on-stop.sh
@@ -4,6 +4,9 @@
 #
 # Supports both plugin mode (CLAUDE_PLUGIN_ROOT) and standalone install.
 
+# Recursion guard: skip when invoked from PI's own `claude -p` subprocess.
+[[ "${PI_SUBPROCESS:-0}" == "1" ]] && exit 0
+
 PI_ROOT="${CLAUDE_PLUGIN_ROOT:-${PI_ROOT:-${EPISODIC_ROOT:-$HOME/.claude/project-intelligence}}}"
 
 # Backward compat: check both pi-* and episodic-* script names
@@ -29,3 +32,6 @@ archive_bin=$(_pi_bin archive)
 if sync_bin=$(_pi_bin knowledge-sync 2>/dev/null); then
     "$sync_bin" push &>/dev/null &
 fi
+
+# CC v2.1.80+ requires valid JSON on stdout
+echo "{}"

--- a/lib/db.sh
+++ b/lib/db.sh
@@ -79,6 +79,11 @@ episodic_db_init() {
     local db="${1:-$EPISODIC_DB}"
     mkdir -p "$(dirname "$db")"
 
+    # Enable WAL mode for concurrent reader/writer access. Without WAL, parallel
+    # backfills + session hooks reading the DB hit SQLITE_BUSY immediately because
+    # busy_timeout=0 default. WAL setting persists in the DB file itself.
+    sqlite3 "$db" "PRAGMA journal_mode=WAL; PRAGMA wal_autocheckpoint=1000;" >/dev/null 2>&1 || true
+
     episodic_db_exec_multi "$db" <<'SQL'
 CREATE TABLE IF NOT EXISTS sessions (
     id TEXT PRIMARY KEY,

--- a/lib/deep-dive.sh
+++ b/lib/deep-dive.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# episodic-memory: Deep dive — comprehensive codebase understanding
+# Generates a structured analysis of what a project IS (architecture, patterns, stack).
+
+_EPISODIC_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_EPISODIC_LIB_DIR/config.sh"
+
+# Collect project context for deep-dive analysis
+# Scans: tree structure, manifests, entry points, README, Dockerfiles, configs
+# Usage: episodic_deep_dive_collect_context <project_path>
+# Output: concatenated context string (truncated to 80K chars)
+episodic_deep_dive_collect_context() {
+    local project_path="$1"
+    local context=""
+    local max_chars=80000
+
+    if [[ ! -d "$project_path" ]]; then
+        episodic_log "ERROR" "Project path does not exist: $project_path"
+        return 1
+    fi
+
+    # 1. Directory tree (depth 4, max 500 entries)
+    context+="## Directory Structure"$'\n'
+    context+="$(find "$project_path" -maxdepth 4 -not -path '*/node_modules/*' -not -path '*/.git/*' -not -path '*/vendor/*' -not -path '*/__pycache__/*' -not -path '*/.venv/*' -not -path '*/target/*' -not -path '*/dist/*' -not -path '*/.next/*' -not -path '*/build/*' 2>/dev/null | head -500 | sed "s|^$project_path/||")"$'\n\n'
+
+    # 2. Manifests / dependency files
+    local manifests=(
+        "package.json"
+        "requirements.txt"
+        "Pipfile"
+        "pyproject.toml"
+        "Cargo.toml"
+        "go.mod"
+        "Gemfile"
+        "pom.xml"
+        "build.gradle"
+        "composer.json"
+        "mix.exs"
+        "Makefile"
+    )
+
+    for manifest in "${manifests[@]}"; do
+        local mpath="$project_path/$manifest"
+        if [[ -f "$mpath" ]]; then
+            context+="## $manifest"$'\n'
+            context+="$(head -100 "$mpath")"$'\n\n'
+        fi
+    done
+
+    # 3. Entry points
+    local entry_patterns=(
+        "src/index.*"
+        "src/main.*"
+        "src/app.*"
+        "main.*"
+        "app.*"
+        "index.*"
+        "server.*"
+        "cmd/main.go"
+        "src/lib.rs"
+    )
+
+    for pattern in "${entry_patterns[@]}"; do
+        # Use find to handle glob in pattern
+        while IFS= read -r entry_file; do
+            [[ -f "$entry_file" ]] || continue
+            # Skip large/binary files
+            local fsize
+            if stat -f%z "$entry_file" &>/dev/null; then
+                fsize=$(stat -f%z "$entry_file")
+            else
+                fsize=$(stat -c%s "$entry_file" 2>/dev/null || echo 0)
+            fi
+            [[ "$fsize" -gt 50000 ]] && continue
+            local rel_path="${entry_file#$project_path/}"
+            context+="## Entry Point: $rel_path"$'\n'
+            context+="$(head -150 "$entry_file")"$'\n\n'
+        done < <(find "$project_path" -maxdepth 3 -path "$project_path/$pattern" 2>/dev/null | head -5)
+    done
+
+    # 4. README and docs
+    for readme in README.md README.rst README.txt README; do
+        if [[ -f "$project_path/$readme" ]]; then
+            context+="## $readme"$'\n'
+            context+="$(head -200 "$project_path/$readme")"$'\n\n'
+            break
+        fi
+    done
+
+    # 5. CLAUDE.md (project-specific instructions)
+    if [[ -f "$project_path/CLAUDE.md" ]]; then
+        context+="## CLAUDE.md"$'\n'
+        context+="$(cat "$project_path/CLAUDE.md")"$'\n\n'
+    fi
+
+    # 6. Docker / CI config
+    for cfg in Dockerfile docker-compose.yml docker-compose.yaml .github/workflows/ci.yml .github/workflows/ci.yaml .gitlab-ci.yml Procfile; do
+        if [[ -f "$project_path/$cfg" ]]; then
+            context+="## $cfg"$'\n'
+            context+="$(head -80 "$project_path/$cfg")"$'\n\n'
+        fi
+    done
+
+    # 7. Config files
+    for cfg in tsconfig.json .eslintrc.json .prettierrc webpack.config.js vite.config.ts next.config.js setup.py setup.cfg; do
+        if [[ -f "$project_path/$cfg" ]]; then
+            context+="## $cfg"$'\n'
+            context+="$(head -50 "$project_path/$cfg")"$'\n\n'
+        fi
+    done
+
+    # Truncate to max chars
+    if [[ ${#context} -gt $max_chars ]]; then
+        context="${context:0:$max_chars}"
+        context+=$'\n\n[... truncated at 80K chars ...]'
+    fi
+
+    echo "$context"
+}
+
+# Generate a deep-dive document via Opus API with extended thinking
+# Usage: episodic_deep_dive_generate <project> <project_path> [--refresh]
+# Output: markdown deep-dive document
+episodic_deep_dive_generate() {
+    local project="$1"
+    local project_path="$2"
+    local refresh="${3:-}"
+
+    episodic_require_api_key || return 1
+
+    local context
+    context=$(episodic_deep_dive_collect_context "$project_path")
+    if [[ -z "$context" ]]; then
+        episodic_log "ERROR" "No context collected for $project"
+        return 1
+    fi
+
+    # Sanitize context: strip control chars that break JSON encoding
+    context=$(printf '%s' "$context" | tr -d '\000-\010\013\014\016-\037')
+
+    local system_prompt='You are a senior software architect analyzing a codebase. Produce a comprehensive, structured deep-dive document in Markdown.
+
+Your analysis MUST cover ALL of these sections (skip a section only if truly not applicable):
+
+# <Project Name> — Deep Dive
+
+## Overview
+What this project does, its purpose, who uses it. 2-3 sentences.
+
+## Tech Stack
+Languages, frameworks, major libraries, runtime. Bullet list.
+
+## Architecture
+High-level architecture: monolith vs microservices, data flow, key components and how they interact. Include a simple ASCII diagram if helpful.
+
+## Directory Structure
+Explain the layout — what lives where and why. Not a raw tree, but a narrated guide.
+
+## Entry Points
+Where execution starts. Main files, CLI entry points, HTTP handlers, event handlers.
+
+## Key Patterns
+Design patterns, conventions, idioms used throughout the codebase. Anti-patterns to be aware of.
+
+## Dependencies
+Critical external dependencies and what they do. Any vendored or unusual deps.
+
+## Deployment
+How this gets deployed. CI/CD, infrastructure, environments.
+
+## Development Workflow
+How to run locally, test, build. Common dev tasks.
+
+## Gotchas
+Non-obvious things a new developer would trip over. Known issues, tech debt, quirks.
+
+Rules:
+- Be specific and concrete — reference actual file paths, function names, config values
+- This is a reference document, not a tutorial. Be dense with information.
+- Use code blocks for file paths, commands, and code snippets
+- Keep total length between 1500-4000 words'
+
+    local user_prompt
+    if [[ "$refresh" == "--refresh" ]] && episodic_deep_dive_exists "$project"; then
+        local previous
+        previous=$(episodic_deep_dive_read "$project")
+        user_prompt="Analyze this codebase context and UPDATE the existing deep-dive document. Focus on what has changed or been added since the last analysis. Add a '## Changes Since Last Analysis' section at the top.
+
+## Previous Deep Dive
+$previous
+
+## Current Codebase Context
+$context
+
+Generate the updated deep-dive document."
+    else
+        user_prompt="Analyze this codebase context and generate a comprehensive deep-dive document.
+
+## Codebase Context
+$context
+
+Generate the deep-dive document."
+    fi
+
+    local model="$EPISODIC_DEEP_DIVE_MODEL"
+    local thinking_budget="$EPISODIC_DEEP_DIVE_THINKING_BUDGET"
+    local timeout="$EPISODIC_DEEP_DIVE_TIMEOUT"
+
+    local request_json
+    request_json=$(jq -n \
+        --arg model "$model" \
+        --arg system "$system_prompt" \
+        --arg user "$user_prompt" \
+        --argjson budget "$thinking_budget" \
+        '{
+            model: $model,
+            max_tokens: ($budget + 8000),
+            thinking: {
+                type: "enabled",
+                budget_tokens: $budget
+            },
+            system: $system,
+            messages: [{
+                role: "user",
+                content: $user
+            }]
+        }')
+
+    if [[ -z "$request_json" ]]; then
+        episodic_log "ERROR" "Failed to build request JSON for deep-dive"
+        return 1
+    fi
+
+    episodic_log "INFO" "Calling $model (thinking=$thinking_budget) for deep-dive of $project..."
+
+    local response
+    response=$(curl -s --max-time "$timeout" \
+        https://api.anthropic.com/v1/messages \
+        -H "x-api-key: $ANTHROPIC_API_KEY" \
+        -H "anthropic-version: 2023-06-01" \
+        -H "content-type: application/json" \
+        -d "$request_json" 2>/dev/null)
+
+    if [[ $? -ne 0 || -z "$response" ]]; then
+        episodic_log "ERROR" "Deep-dive API call failed (timeout or network error)"
+        return 1
+    fi
+
+    # Check for API errors
+    local error_type
+    error_type=$(echo "$response" | jq -r '.error.type // empty' 2>/dev/null)
+    if [[ -n "$error_type" ]]; then
+        local error_msg
+        error_msg=$(echo "$response" | jq -r '.error.message // "unknown error"' 2>/dev/null)
+        episodic_log "ERROR" "Deep-dive API error ($model): $error_type - $error_msg"
+        return 1
+    fi
+
+    # Extract text content (handle thinking response)
+    local content
+    content=$(echo "$response" | jq -r '[.content[] | select(.type == "text")] | last | .text // empty' 2>/dev/null)
+
+    if [[ -z "$content" ]]; then
+        episodic_log "ERROR" "No text content in deep-dive API response"
+        return 1
+    fi
+
+    # Log usage stats
+    local input_tokens output_tokens
+    input_tokens=$(echo "$response" | jq -r '.usage.input_tokens // 0' 2>/dev/null)
+    output_tokens=$(echo "$response" | jq -r '.usage.output_tokens // 0' 2>/dev/null)
+    episodic_log "INFO" "Deep-dive API usage: ${input_tokens} in / ${output_tokens} out ($model)"
+
+    echo "$content"
+}
+
+# Write deep-dive document to knowledge directory with YAML frontmatter
+# Usage: episodic_deep_dive_write <project> <content> <project_path> <model>
+episodic_deep_dive_write() {
+    local project="$1"
+    local content="$2"
+    local project_path="$3"
+    local model="${4:-$EPISODIC_DEEP_DIVE_MODEL}"
+
+    # Sanitize project name to prevent path traversal
+    project=$(episodic_sanitize_name "$project")
+
+    local dir="$EPISODIC_KNOWLEDGE_DIR/$project"
+    mkdir -p -m 700 "$dir"
+
+    local generated
+    generated=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    local target="$dir/deep-dive.md"
+
+    # Refuse to write to symlinks
+    if [[ -L "$target" ]]; then
+        episodic_log "ERROR" "Refusing to write to symlink: $target"
+        return 1
+    fi
+
+    # Use printf to avoid shell expansion of $content (which comes from LLM API)
+    {
+        printf '%s\n' "---"
+        printf 'type: deep-dive\n'
+        printf 'project: %s\n' "$project"
+        printf 'generated: %s\n' "$generated"
+        printf 'model: %s\n' "$model"
+        printf 'project_path: %s\n' "$project_path"
+        printf '%s\n\n' "---"
+        printf '%s\n' "$content"
+    } > "$target"
+
+    episodic_log "INFO" "Wrote deep-dive for $project to $dir/deep-dive.md"
+}
+
+# Check if a deep-dive exists for a project
+# Usage: episodic_deep_dive_exists <project>
+# Returns: 0 if exists, 1 if not
+episodic_deep_dive_exists() {
+    local project="$1"
+    project=$(episodic_sanitize_name "$project")
+    [[ -f "$EPISODIC_KNOWLEDGE_DIR/$project/deep-dive.md" ]]
+}
+
+# Read deep-dive content, stripping YAML frontmatter
+# Usage: episodic_deep_dive_read <project>
+# Output: body of deep-dive.md without frontmatter
+episodic_deep_dive_read() {
+    local project="$1"
+    project=$(episodic_sanitize_name "$project")
+    local file="$EPISODIC_KNOWLEDGE_DIR/$project/deep-dive.md"
+
+    if [[ ! -f "$file" ]]; then
+        episodic_log "WARN" "No deep-dive found for $project"
+        return 1
+    fi
+
+    # Strip YAML frontmatter (everything between first two --- lines)
+    awk 'BEGIN{f=0} /^---$/{f++; next} f>=2' "$file"
+}

--- a/lib/index.sh
+++ b/lib/index.sh
@@ -305,15 +305,20 @@ episodic_index_stats() {
 
     local total
     total=$(episodic_db_exec "SELECT count(*) FROM documents;" "$db")
+    # sqlite3 returns empty string when no rows; jq --argjson rejects empty.
+    [[ -z "$total" ]] && total=0
 
     local by_project
     by_project=$(episodic_db_query_json "SELECT project, count(*) as count FROM documents GROUP BY project;" "$db")
+    [[ -z "$by_project" ]] && by_project="[]"
 
     local by_type
     by_type=$(episodic_db_query_json "SELECT file_type, count(*) as count FROM documents GROUP BY file_type;" "$db")
+    [[ -z "$by_type" ]] && by_type="[]"
 
     local total_size
     total_size=$(episodic_db_exec "SELECT coalesce(sum(file_size), 0) FROM documents;" "$db")
+    [[ -z "$total_size" ]] && total_size=0
 
     jq -n \
         --argjson total "$total" \

--- a/lib/progression.sh
+++ b/lib/progression.sh
@@ -742,37 +742,36 @@ Rules:
         return 1
     fi
 
-    episodic_log "INFO" "Reflecting on $project / $topic ($doc_count docs, model=$model)..."
+    # === CLI swap: headless `claude -p` instead of api.anthropic.com ===
+    # Auto path: sonnet. Deep path: opus (EPISODIC_DEEP=1).
+    local cli_model
+    case "$model" in
+        *opus*) cli_model="opus" ;;
+        *haiku*) cli_model="haiku" ;;
+        *sonnet*) cli_model="sonnet" ;;
+        *)
+            if [[ "${EPISODIC_DEEP:-0}" == "1" ]]; then
+                cli_model="opus"
+            else
+                cli_model="sonnet"
+            fi
+            ;;
+    esac
+    episodic_log "INFO" "Reflecting on $project / $topic ($doc_count docs, model=$cli_model via claude -p)..."
 
-    local response
-    response=$(curl -s --max-time 120 \
-        https://api.anthropic.com/v1/messages \
-        -H "x-api-key: $ANTHROPIC_API_KEY" \
-        -H "anthropic-version: 2023-06-01" \
-        -H "content-type: application/json" \
-        -d "$request_json" 2>/dev/null)
+    # Build prompt: system + docs + instruction
+    local full_prompt
+    full_prompt=$(printf '%s\n\nAnalyze this knowledge progression on: "%s"\n\n%s\n\nOutput ONLY the JSON object.' "$system_prompt" "$ptopic" "$all_docs")
 
-    if [[ $? -ne 0 || -z "$response" ]]; then
-        episodic_log "ERROR" "pi_progression_reflect: API call failed"
-        return 1
-    fi
-
-    # Check for API errors
-    local error_type
-    error_type=$(echo "$response" | jq -r '.error.type // empty' 2>/dev/null)
-    if [[ -n "$error_type" ]]; then
-        local error_msg
-        error_msg=$(echo "$response" | jq -r '.error.message // "unknown error"' 2>/dev/null)
-        episodic_log "ERROR" "pi_progression_reflect: API error: $error_type - $error_msg"
-        return 1
-    fi
-
-    # Extract text content (handle thinking responses)
+    # PI_SUBPROCESS=1 prevents PI's own hooks from firing in the subprocess (recursion guard).
     local raw_content
-    raw_content=$(echo "$response" | jq -r '[.content[] | select(.type == "text")] | last | .text // empty' 2>/dev/null)
+    # Absolute path required: in non-interactive subshells the `claude` shell function
+    # is not loaded and ~/.local/bin may not be on PATH. Stderr captured for diagnostics.
+    raw_content=$(printf '%s' "$full_prompt" | timeout 180 env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN PI_SUBPROCESS=1 CLAUDE_CODE_OAUTH_TOKEN="$(security find-generic-password -s Claude-Code-OAuth-Token -w 2>/dev/null)" "$HOME/.local/bin/claude" --print --model "$cli_model" 2>>"${EPISODIC_LOG_FILE:-/tmp/pi-progression-stderr.log}")
+    local cli_rc=$?
 
-    if [[ -z "$raw_content" ]]; then
-        episodic_log "ERROR" "pi_progression_reflect: no text in API response"
+    if [[ $cli_rc -ne 0 || -z "$raw_content" ]]; then
+        episodic_log "ERROR" "pi_progression_reflect: claude -p call failed (rc=$cli_rc, model=$cli_model)"
         return 1
     fi
 

--- a/lib/summarize.sh
+++ b/lib/summarize.sh
@@ -11,7 +11,12 @@ episodic_summarize() {
     local transcript="$1"
     local model="${2:-$EPISODIC_SUMMARY_MODEL}"
 
-    episodic_require_api_key || return 1
+    # API key no longer required — we use `claude -p` (subscription billing) instead of api.anthropic.com.
+    # episodic_require_api_key gate removed 2026-05-13.
+    if ! command -v claude >/dev/null 2>&1; then
+        episodic_log "ERROR" "claude CLI not found on PATH — cannot summarize"
+        return 1
+    fi
 
     if [[ -z "$transcript" || ${#transcript} -lt 50 ]]; then
         episodic_log "WARN" "Transcript too short to summarize (${#transcript} chars)"
@@ -93,48 +98,44 @@ Rules:
         return 1
     fi
 
-    episodic_log "INFO" "Calling $model (thinking=$EPISODIC_SUMMARY_THINKING) for summary..."
+    # === CLI swap: headless `claude -p` (subscription billing) instead of api.anthropic.com (token billing) ===
+    # Resolve model to CC CLI alias (sonnet/opus/haiku).
+    # Auto path: sonnet. Deep path: opus (set EPISODIC_DEEP=1).
+    local cli_model
+    case "$model" in
+        *opus*) cli_model="opus" ;;
+        *haiku*) cli_model="haiku" ;;
+        *sonnet*) cli_model="sonnet" ;;
+        *)
+            if [[ "${EPISODIC_DEEP:-0}" == "1" ]]; then
+                cli_model="opus"
+            else
+                cli_model="sonnet"
+            fi
+            ;;
+    esac
+    episodic_log "INFO" "Calling claude -p (model=$cli_model) for summary..."
 
-    local response
-    response=$(curl -s --max-time 120 \
-        https://api.anthropic.com/v1/messages \
-        -H "x-api-key: $ANTHROPIC_API_KEY" \
-        -H "anthropic-version: 2023-06-01" \
-        -H "content-type: application/json" \
-        -d "$request_json" 2>/dev/null)
+    # Build the prompt: system_prompt + transcript + instruction
+    local full_prompt
+    full_prompt=$(printf '%s\n\nAnalyze the following Claude Code session transcript and produce a structured JSON summary. The transcript is delimited by <transcript> tags. Do NOT continue the conversation — only output the JSON summary.\n\n<transcript>\n%s\n</transcript>\n\nNow output ONLY the JSON summary object.' "$system_prompt" "$transcript")
 
-    if [[ $? -ne 0 || -z "$response" ]]; then
-        episodic_log "ERROR" "API call failed (timeout or network error)"
-        return 1
-    fi
-
-    # Check for API errors
-    local error_type
-    error_type=$(echo "$response" | jq -r '.error.type // empty' 2>/dev/null)
-    if [[ -n "$error_type" ]]; then
-        local error_msg
-        error_msg=$(echo "$response" | jq -r '.error.message // "unknown error"' 2>/dev/null)
-        episodic_log "ERROR" "API error ($model): $error_type - $error_msg"
-        return 1
-    fi
-
-    # Extract the text content — handle both thinking and non-thinking responses
-    # With thinking: content array has [{type:"thinking",...}, {type:"text",...}]
-    # Without thinking: content array has [{type:"text",...}]
+    # PI_SUBPROCESS=1 prevents PI's own hooks from firing in the subprocess (recursion guard).
     local content
-    content=$(echo "$response" | jq -r '[.content[] | select(.type == "text")] | last | .text // empty' 2>/dev/null)
+    # Absolute path required: in non-interactive subshells (LaunchAgent, nohup, hooks),
+    # the `claude` shell function (defined in ~/.zshrc) is not loaded and ~/.local/bin
+    # may not be on PATH. Stderr captured for diagnostics.
+    # 300s covers ~2-3 MB transcripts; 180s was too tight for vertical-sora sessions
+    # (3 SIGTERM rc=143 on 2-day backfill before bump).
+    content=$(printf '%s' "$full_prompt" | timeout 300 env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN PI_SUBPROCESS=1 CLAUDE_CODE_OAUTH_TOKEN="$(security find-generic-password -s Claude-Code-OAuth-Token -w 2>/dev/null)" "$HOME/.local/bin/claude" --print --model "$cli_model" 2>>"${EPISODIC_LOG_FILE:-/tmp/pi-summarize-stderr.log}")
+    local cli_rc=$?
 
-    if [[ -z "$content" ]]; then
-        episodic_log "ERROR" "No text content in API response"
-        episodic_log "DEBUG" "Response keys: $(echo "$response" | jq -c 'keys' 2>/dev/null)"
+    if [[ $cli_rc -ne 0 || -z "$content" ]]; then
+        episodic_log "ERROR" "claude -p call failed (rc=$cli_rc, model=$cli_model)"
         return 1
     fi
 
-    # Log usage stats
-    local input_tokens output_tokens
-    input_tokens=$(echo "$response" | jq -r '.usage.input_tokens // 0' 2>/dev/null)
-    output_tokens=$(echo "$response" | jq -r '.usage.output_tokens // 0' 2>/dev/null)
-    episodic_log "INFO" "API usage: ${input_tokens} in / ${output_tokens} out ($model)"
+    episodic_log "INFO" "claude -p call succeeded (model=$cli_model, $(printf '%s' "$content" | wc -c | tr -d ' ') bytes)"
 
     # Extract JSON from response — handle multiple formats:
     # 1. Raw JSON (ideal)


### PR DESCRIPTION
## What

Swaps PI's session summarizer and progression reflector from `api.anthropic.com` (API-token billing) to the headless `claude -p` CLI (Claude subscription billing), and hardens the backfill path so it survives large parallel runs.

## Changes

**Billing / model path**
- `lib/summarize.sh`, `lib/progression.sh`: call `claude --print --model <alias>` instead of POSTing to `api.anthropic.com`; drop the `ANTHROPIC_API_KEY` requirement. Model resolves to `sonnet` by default, `opus` when `EPISODIC_DEEP=1`.
  - `PI_SUBPROCESS=1` recursion guard so PI's own hooks don't fire inside the subprocess.
  - `env -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN` + `CLAUDE_CODE_OAUTH_TOKEN` from keychain so the subprocess uses subscription auth.
  - Absolute `"$HOME/.local/bin/claude"` (the `claude` shell function isn't loaded in non-interactive subshells / LaunchAgents); stderr captured for diagnostics.
  - Timeouts: 300s summarize (large transcripts), 180s reflect.

**Concurrency / scale**
- `lib/db.sh`: enable `PRAGMA journal_mode=WAL` + `wal_autocheckpoint` on init so parallel backfills + session hooks don't hit `SQLITE_BUSY` (default `busy_timeout=0`).
- `bin/pi-backfill`: `--id-prefix` / `--ids-file` sharding for parallel runs; `archive_path` fallback when the source bucket file has been deleted; stderr log.
- `bin/pi-archive`, `bin/pi-backfill`: `--deep` flag (`EPISODIC_DEEP=1` -> opus).

**Robustness**
- `lib/index.sh`: guard empty `sqlite3` results before `jq --argjson` (empty string was rejected).
- `bin/pi-analyze`: fall back to `archive/lib/deep-dive.sh` if the canonical `lib/deep-dive.sh` is missing.
- `hooks/on-session-start.sh`, `hooks/on-stop.sh`: `PI_SUBPROCESS` recursion guard; `on-stop` emits `{}` for the CC v2.1.80+ JSON-on-stdout requirement.
- `lib/deep-dive.sh`: restored (was archived upstream but is still sourced by `pi-analyze`).
- `.claude-plugin/marketplace.json`: marketplace manifest.

## Notes for reviewer
- Opened as **draft** from a fork. Paths are portable (`$HOME`), keychain service `Claude-Code-OAuth-Token` is the standard CC OAuth entry — no secret values are embedded (runtime keychain read).
- The `claude -p` swap trades API-token billing for subscription billing; that's an intentional cost choice and may not suit all installs. Could be gated behind an env flag (e.g. `EPISODIC_BACKEND=cli|api`) if you'd prefer to keep the API path as default.